### PR TITLE
remove edit_url from playbook

### DIFF
--- a/component_hub/templates/playbook.yml
+++ b/component_hub/templates/playbook.yml
@@ -9,7 +9,6 @@ content:
     - url: . # The current folder is a git repo
       branches: HEAD # "HEAD" uses whichever branch is currently checked out
       start_path: docs
-      edit_url: "https://github.com/projectsyn/component-hub/edit/master/{path}"
 ui:
   bundle:
     url: https://github.com/projectsyn/antora-ui-default/releases/download/2.1.0/ui-bundle.zip


### PR DESCRIPTION
since the page source tree is auto-generated, the "edit page" button on the generated HTML points to inexistent files in this git repo (that are created at page-compile-time). Removing edit_url config should remove the edit page button on the generated site