### PR TITLE
Ensure that Antora can build the generated site

### DIFF
--- a/.github/workflows/hub.yml
+++ b/.github/workflows/hub.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           name: antora-site-configuration
           path: build/
+          include-hidden-files: true
 
   build:
     name: Build Antora Site 💪


### PR DESCRIPTION
Recent versions of `actions/upload-artifact@v4` don't include hidden files by default anymore. This causes an error in the GitHub workflow since Antora refuses to render a site which isn't stored in a Git repository.

This commit ensures that hidden files are included in the artifact that's used to share the generated Antora sources between the workflow jobs.