### PR TITLE
Configure Renovate to only update upper end of Python version range

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,11 @@
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true
+    },
+    {
+        "matchManagers": ["poetry"],
+        "matchPackageNames": ["python"],
+        "rangeStrategy": "replace"
     }
   ]
 }


### PR DESCRIPTION
According to https://github.com/renovatebot/renovate/discussions/24254#discussioncomment-6918516, we need to have a package rule for Python which sets `rangeStrategy=replace` to ensure that Renovate only updates the upper end of the range instead of replacing ">=3.9, <3.13" with ">=3.13, <3.14".